### PR TITLE
feat: Default to parakeet device on macOS

### DIFF
--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -101,12 +101,14 @@ def parse_arguments() -> argparse.Namespace:
         choices=[None] + whisper_options["language"],
     )
     choices = [None, "cpu", "cuda", "insane", "groq"]
+    default_device = None
     if platform.system() == "Darwin":
         choices.extend(["mlx", "mps", "parakeet"])  # mps for backward compatibility, parakeet for CoreML Parakeet TDT
+        default_device = "parakeet"  # Default to parakeet on macOS
     parser.add_argument(
         "--device",
-        help="device to use for processing, None will auto select CUDA if available or else CPU. Use 'groq' for Groq API, 'parakeet' for CoreML Parakeet TDT (macOS only)",
-        default=None,
+        help="device to use for processing. On macOS defaults to 'parakeet' (CoreML Parakeet TDT). Otherwise auto selects CUDA if available or else CPU. Use 'groq' for Groq API.",
+        default=default_device,
         choices=choices,
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

This PR changes the default transcription device on macOS to `parakeet` (CoreML Parakeet TDT).

## Changes

- On macOS, the default `--device` is now `parakeet` instead of `None` (which would auto-detect)
- This provides faster transcription using Apple Silicon MLX via the parakeet-mlx library
- Other platforms continue to auto-detect CUDA or fall back to CPU

## Usage

After this change, on macOS you can simply run:
```bash
transcribe-anything video.mp4
```

This will automatically use the Parakeet TDT model for transcription.

To use a different device, explicitly specify it:
```bash
transcribe-anything video.mp4 --device cpu
transcribe-anything video.mp4 --device mlx
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author