### PR TITLE
Use CoreML Parakeet v3 by default on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,56 @@
 
 ![image](https://github.com/zackees/transcribe-anything/assets/6856673/94bdd1fe-3225-438a-ac1b-09c81f1d4108)
 
-### USES WHISPER AI
+### LOCAL SPEECH-TO-TEXT
 
 Over 700+⭐'s because this program this app just works! Works great for windows and mac. This whisper front-end app is the only one to generate a `speaker.json` file which partitions the conversation by who doing the speaking.
 
 [![Star History Chart](https://api.star-history.com/svg?repos=zackees/transcribe-anything&type=Date)](https://star-history.com/#zackees/transcribe-anything&Date)
+
+### New in 3.3!
+
+**Apple Silicon now defaults to the audited FluidAudio/CoreML Parakeet v3 int8 backend.**
+
+```bash
+# Default on Apple Silicon. English, local, word-timed, filler-aware.
+transcribe-anything video.mp4 --language en
+
+# Equivalent explicit command.
+transcribe-anything video.mp4 --device parakeet --model parakeet-v3 --language en
+
+# Explicit legacy rollback only.
+transcribe-anything video.mp4 --device parakeet-mlx --model parakeet-v2 --language en
+```
+
+The CoreML result includes standard `out.json`, `out.txt`, `out.srt`, and
+`out.vtt` files. `out.json` also contains calibrated, reviewable
+`filler_events` for literal `um`, `uh`, `ah`, and `mmm` sounds. These events
+describe what was heard; `editorial_decision` remains `unreviewed` until a
+person or editing workflow decides whether the sound should be removed.
+
+`--device parakeet` resolves `FluidAudioCLI` from
+`TRANSCRIBE_ANYTHING_FLUIDAUDIO_BINARY`, the current `PATH`, or
+`~/.local/lib/transcribe-anything/FluidAudioCLI`. It never downloads an
+executable at runtime.
+
+Build and install the audited Apache-2.0 FluidAudio CLI on macOS 14+ with
+Xcode/Swift 6:
+
+```bash
+git clone https://github.com/FluidInference/FluidAudio.git
+cd FluidAudio
+git checkout 88d6d8166880dee1ac7c32c80f8e10cd782f8ca8
+swift build -c release --product fluidaudiocli
+install -d ~/.local/lib/transcribe-anything
+install -m 755 "$(swift build -c release --show-bin-path)/fluidaudiocli" \
+  ~/.local/lib/transcribe-anything/FluidAudioCLI
+```
+
+The validated arm64 build had SHA-256
+`a4c2a4dba49005e8e91ead57a38b3a1d96e0d81040a96c3d00d31c84e5fc1b69`.
+FluidAudio currently resolves model files from the model repository's `main`
+revision. Backend metadata therefore distinguishes the audited model revision
+from an actually enforced revision instead of claiming the download is pinned.
 
 ### New in 3.2!
 
@@ -76,8 +121,8 @@ transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ
 # GPU accelerated (Windows/Linux)
 transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device insane
 
-# Mac Apple Silicon accelerated
-transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device mlx
+# Mac Apple Silicon accelerated (default)
+transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device parakeet --model parakeet-v3
 
 # Groq API (fastest, requires API key)
 export GROQ_API_KEY="your_groq_api_key_here"
@@ -113,10 +158,10 @@ transcribe_anything(
 def transcribe(
     url_or_file: str,
     output_dir: Optional[str] = None,
-    model: Optional[str] = None,              # tiny,small,medium,large
+    model: Optional[str] = None,              # Whisper models or parakeet-v2/v3/110m
     task: Optional[str] = None,               # transcribe or translate
     language: Optional[str] = None,           # auto detected if none, "en" for english...
-    device: Optional[str] = None,             # cuda,cpu,insane,mlx,groq
+    device: Optional[str] = None,             # cuda,cpu,insane,mlx,groq,parakeet,parakeet-mlx
     embed: bool = False,                      # Produces a video.mp4 with the subtitles burned in.
     hugging_face_token: Optional[str] = None, # If you want a speaker.json
     other_args: Optional[list[str]] = None,   # Other args to be passed to to the whisper backend
@@ -200,7 +245,7 @@ We have a [Dockerfile](Dockerfile) that will be descently fast for startup. It i
 
 # GPU Acceleration
 
-GPU acceleration will be automatically enabled for windows and linux. Mac users can use `--device mlx` for hardware acceleration on Apple Silicon. `--device insane` may also work on Mac M1+ but has been less tested.
+GPU acceleration will be automatically enabled for windows and linux. Apple Silicon Macs default to `--device parakeet`, which runs FluidAudio/CoreML Parakeet v3 int8. `--device mlx` remains available for Whisper, while `--device parakeet-mlx` is the explicit legacy Parakeet rollback.
 
 Windows/Linux:
 
@@ -208,7 +253,7 @@ Windows/Linux:
 
 Mac:
 
-- Use `--device mlx`
+- Use `--device parakeet` (default on Apple Silicon)
 
 # Groq API Integration
 
@@ -276,6 +321,8 @@ transcribe-anything large_podcast.mp3 --device groq --model whisper-large-v3-tur
 
 | Backend | Device Flag | Key Arguments | Best For |
 |---------|-------------|---------------|----------|
+| **Parakeet CoreML** | `--device parakeet` | `--model parakeet-v3`, `--language en` | Default local English transcription, word timestamps, literal filler events on Apple Silicon |
+| **Parakeet MLX (legacy)** | `--device parakeet-mlx` | `--model parakeet-v2` or `parakeet-v3` | Explicit rollback and comparisons on Apple Silicon |
 | **Groq API** | `--device groq` | `--groq_api_key`, `--initial_prompt` | Fastest transcription (cloud) |
 | **MLX** | `--device mlx` | `--batch_size`, `--verbose`, `--initial_prompt` | Mac Apple Silicon |
 | **Insanely Fast** | `--device insane` | `--batch-size`, `--hf_token`, `--flash`, `--timestamp` | Windows/Linux GPU |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "groq>=0.11.0",
 ]
 # VERSION
-version = "3.2.2"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "3.3.0"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.urls]

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -104,10 +104,13 @@ def parse_arguments() -> argparse.Namespace:
     default_device = None
     if platform.system() == "Darwin":
         choices.extend(["mlx", "mps", "parakeet"])  # mps for backward compatibility, parakeet for CoreML Parakeet TDT
-        default_device = "parakeet"  # Default to parakeet on macOS
+        # Only default to parakeet on Apple Silicon (arm64), not Intel Macs
+        from transcribe_anything.util import is_mac_arm
+        if is_mac_arm():
+            default_device = "parakeet"  # Default to parakeet on Apple Silicon macOS
     parser.add_argument(
         "--device",
-        help="device to use for processing. On macOS defaults to 'parakeet' (CoreML Parakeet TDT). Otherwise auto selects CUDA if available or else CPU. Use 'groq' for Groq API.",
+        help="device to use for processing. On Apple Silicon macOS defaults to 'parakeet' (CoreML Parakeet TDT). Otherwise auto selects CUDA if available or else CPU. Use 'groq' for Groq API.",
         default=default_device,
         choices=choices,
     )

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -38,6 +38,9 @@ WHISPER_MODEL_OPTIONS = [
     "large-v2",
     "large-v3",
     "distil-whisper/distil-large-v2",
+    "parakeet-v2",
+    "parakeet-v3",
+    "parakeet-110m",
 ]
 
 
@@ -84,7 +87,7 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--model",
-        help="name of the Whisper model to us",
+        help="ASR model. On Apple Silicon the default device maps unspecified Whisper names to parakeet-v3.",
         default="small",
         choices=WHISPER_MODEL_OPTIONS,
     )
@@ -103,14 +106,14 @@ def parse_arguments() -> argparse.Namespace:
     choices = [None, "cpu", "cuda", "insane", "groq"]
     default_device = None
     if platform.system() == "Darwin":
-        choices.extend(["mlx", "mps", "parakeet"])  # mps for backward compatibility, parakeet for CoreML Parakeet TDT
+        choices.extend(["mlx", "mps", "parakeet", "parakeet-mlx"])
         # Only default to parakeet on Apple Silicon (arm64), not Intel Macs
         from transcribe_anything.util import is_mac_arm
         if is_mac_arm():
             default_device = "parakeet"  # Default to parakeet on Apple Silicon macOS
     parser.add_argument(
         "--device",
-        help="device to use for processing. On Apple Silicon macOS defaults to 'parakeet' (CoreML Parakeet TDT). Otherwise auto selects CUDA if available or else CPU. Use 'groq' for Groq API.",
+        help="device to use for processing. On Apple Silicon macOS defaults to 'parakeet' (FluidAudio/CoreML Parakeet v3 int8). Use 'parakeet-mlx' only as an explicit rollback. Otherwise auto selects CUDA if available or else CPU. Use 'groq' for Groq API.",
         default=default_device,
         choices=choices,
     )

--- a/src/transcribe_anything/api.py
+++ b/src/transcribe_anything/api.py
@@ -26,6 +26,7 @@ from transcribe_anything.audio import fetch_audio
 from transcribe_anything.groq_whisper import run_groq_whisper
 from transcribe_anything.insanely_fast_whisper import run_insanely_fast_whisper
 from transcribe_anything.logger import log_error
+from transcribe_anything.parakeet_coreml import run_parakeet_coreml
 from transcribe_anything.parakeet_mlx import run_parakeet_mlx
 from transcribe_anything.util import chop_double_extension, sanitize_filename
 from transcribe_anything.whisper import get_computing_device, run_whisper
@@ -57,6 +58,7 @@ class Device(Enum):
     MLX = "mlx"
     GROQ = "groq"
     PARAKEET = "parakeet"
+    PARAKEET_MLX = "parakeet-mlx"
 
     def __str__(self) -> str:
         return self.value
@@ -81,8 +83,12 @@ class Device(Enum):
             return Device.GROQ
         if device == "parakeet":
             if sys.platform != "darwin":
-                raise ValueError("Parakeet (CoreML/MLX) is only supported on macOS.")
+                raise ValueError("Parakeet CoreML is only supported on macOS.")
             return Device.PARAKEET
+        if device == "parakeet-mlx":
+            if sys.platform != "darwin":
+                raise ValueError("Parakeet MLX is only supported on macOS.")
+            return Device.PARAKEET_MLX
         # Backward compatibility: accept 'mps' as alias for 'mlx'
         if device == "mps":
             if sys.platform != "darwin":
@@ -264,6 +270,10 @@ def transcribe(
             print("#####################################")
             print("####### PARAKEET CoreML MODE! #######")
             print("#####################################")
+        elif device_enum == Device.PARAKEET_MLX:
+            print("#####################################")
+            print("######## PARAKEET MLX MODE! #########")
+            print("#####################################")
         else:
             raise ValueError(f"Unknown device {device}")
         print(f"Using device {device}")
@@ -278,7 +288,7 @@ def transcribe(
             other_args.extend(["--initial_prompt", initial_prompt])
             print(f"Using initial prompt: {initial_prompt[:100]}{'...' if len(initial_prompt) > 100 else ''}")
 
-        print(f"Running whisper on {tmp_wav} (will install models on first run)")
+        print(f"Running ASR on {tmp_wav} (the selected backend may install models on first run)")
         with tempfile.TemporaryDirectory() as tmpdir:
             if device_enum == Device.GROQ:
                 run_groq_whisper(
@@ -304,6 +314,14 @@ def transcribe(
             elif device_enum == Device.MLX:
                 run_whisper_mac_mlx(input_wav=Path(tmp_wav), model=model_str, output_dir=Path(tmpdir), language=language_str if language_str else None, task=task_str, other_args=other_args)
             elif device_enum == Device.PARAKEET:
+                run_parakeet_coreml(
+                    input_wav=Path(tmp_wav),
+                    model=model_str,
+                    output_dir=Path(tmpdir),
+                    language=language_str if language_str else None,
+                    other_args=other_args,
+                )
+            elif device_enum == Device.PARAKEET_MLX:
                 run_parakeet_mlx(
                     input_wav=Path(tmp_wav),
                     model=model_str,

--- a/src/transcribe_anything/parakeet_coreml.py
+++ b/src/transcribe_anything/parakeet_coreml.py
@@ -1,0 +1,204 @@
+"""Run the pinned FluidAudio/CoreML Parakeet backend on Apple Silicon."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from transcribe_anything.parakeet_mlx import _generate_output_files
+
+FLUIDAUDIO_IMPLEMENTATION_REVISION = "88d6d8166880dee1ac7c32c80f8e10cd782f8ca8"
+COREML_V3_AUDITED_MODEL_REVISION = "aed02740059203c4a87495924f685de3722ae9ce"
+DEFAULT_BINARY = Path.home() / ".local" / "lib" / "transcribe-anything" / "FluidAudioCLI"
+FILLER_END_CORRECTION_S = {"um": 0.16, "uh": 0.14}
+FILLER_FALLBACK_END_CORRECTION_S = 0.15
+FILLER_SURFACES = {
+    "um": "um",
+    "umm": "um",
+    "uhm": "um",
+    "umh": "um",
+    "uh": "uh",
+    "ah": "ah",
+    "hm": "mmm",
+    "hmm": "mmm",
+    "mm": "mmm",
+    "mmm": "mmm",
+}
+
+
+def resolve_fluidaudio_binary() -> Path:
+    """Resolve the audited FluidAudio CLI without downloading executables."""
+    configured = os.environ.get("TRANSCRIBE_ANYTHING_FLUIDAUDIO_BINARY")
+    candidates = [Path(configured).expanduser()] if configured else []
+    for command in ("fluidaudio", "FluidAudioCLI"):
+        found = shutil.which(command)
+        if found:
+            candidates.append(Path(found))
+    candidates.append(DEFAULT_BINARY)
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate.resolve()
+    raise RuntimeError(
+        "FluidAudioCLI is required for --device parakeet. Install the audited "
+        f"binary at {DEFAULT_BINARY}, put fluidaudio on PATH, or set "
+        "TRANSCRIBE_ANYTHING_FLUIDAUDIO_BINARY. Use --device parakeet-mlx "
+        "only as an explicit rollback."
+    )
+
+
+def model_version(model: str) -> str:
+    """Map an optional Parakeet model selector to FluidAudio's CLI value."""
+    normalized = (model or "").lower()
+    if normalized in {"parakeet-v2", "v2"}:
+        return "v2"
+    if normalized in {"parakeet-110m", "parakeet-tdt-ctc-110m", "110m"}:
+        return "110m"
+    return "v3"
+
+
+def _display_text(words: list[dict[str, Any]]) -> str:
+    return " ".join(str(word["word"]).strip() for word in words).strip()
+
+
+def _sentences_from_words(raw_words: list[dict[str, Any]], full_text: str) -> list[dict[str, Any]]:
+    """Group lexical CoreML words into compact timestamped caption sentences."""
+    words = [
+        {
+            "word": str(word["word"]).strip(),
+            "start": float(word["startTime"]),
+            "end": float(word["endTime"]),
+            "confidence": word.get("confidence"),
+        }
+        for word in raw_words
+        if str(word.get("word", "")).strip()
+    ]
+    if not words:
+        return [{"text": full_text, "start": 0.0, "end": 0.0, "duration": 0.0, "words": []}] if full_text else []
+
+    sentences: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] = []
+    for index, word in enumerate(words):
+        current.append(word)
+        next_word = words[index + 1] if index + 1 < len(words) else None
+        duration = current[-1]["end"] - current[0]["start"]
+        gap = next_word["start"] - word["end"] if next_word else 0.0
+        terminal = bool(re.search(r"[.!?][\"')\]]*$", word["word"]))
+        should_close = next_word is None or terminal or gap >= 0.8 or duration >= 8.0 or len(_display_text(current)) >= 120
+        if not should_close:
+            continue
+        text = _display_text(current)
+        start = current[0]["start"]
+        end = current[-1]["end"]
+        sentences.append({"text": text, "start": start, "end": end, "duration": end - start, "words": current})
+        current = []
+    return sentences
+
+
+def _normalize_filler(value: str) -> str | None:
+    cleaned = re.sub(r"[^a-z]", "", value.lower())
+    return FILLER_SURFACES.get(cleaned)
+
+
+def _filler_events(sentences: list[dict[str, Any]], duration_s: float) -> list[dict[str, Any]]:
+    """Emit audible filler candidates without making an editorial decision."""
+    events = []
+    for sentence in sentences:
+        for word in sentence["words"]:
+            surface = _normalize_filler(word["word"])
+            if surface is None:
+                continue
+            raw_end = float(word["end"])
+            correction = FILLER_END_CORRECTION_S.get(surface, FILLER_FALLBACK_END_CORRECTION_S)
+            events.append(
+                {
+                    "surface": surface,
+                    "raw_surface": word["word"],
+                    "start": float(word["start"]),
+                    "end": round(min(duration_s, raw_end + correction), 3),
+                    "raw_end": raw_end,
+                    "end_correction_s": correction,
+                    "confidence": word.get("confidence"),
+                    "event_type": "literal_filler",
+                    "editorial_decision": "unreviewed",
+                }
+            )
+    return events
+
+
+def convert_fluidaudio_result(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert FluidAudio JSON to transcribe-anything's stable output shape."""
+    duration_s = float(raw.get("durationSeconds", 0.0))
+    sentences = _sentences_from_words(raw.get("wordTimings", []), str(raw.get("text", "")))
+    version = str(raw.get("modelVersion", "v3"))
+    return {
+        "schema_version": "transcribe_anything.parakeet_coreml.v1",
+        "text": str(raw.get("text", "")),
+        "sentences": sentences,
+        "filler_events": _filler_events(sentences, duration_s),
+        "backend": {
+            "implementation": "FluidAudio/CoreML",
+            "implementation_revision": FLUIDAUDIO_IMPLEMENTATION_REVISION,
+            "model": f"parakeet-{version}-int8",
+            "model_revision": None,
+            "audited_model_revision": COREML_V3_AUDITED_MODEL_REVISION if version == "v3" else None,
+            "model_revision_enforced": False,
+            "encoder_precision": "int8",
+            "filler_boundary_calibration": {
+                "um_end_s": FILLER_END_CORRECTION_S["um"],
+                "uh_end_s": FILLER_END_CORRECTION_S["uh"],
+                "fallback_end_s": FILLER_FALLBACK_END_CORRECTION_S,
+                "fit_role": "isolated teacher-development data; detection remains separate from removal",
+            },
+        },
+        "performance": {
+            "audio_duration_s": duration_s,
+            "inference_s": raw.get("processingTimeSeconds"),
+            "rtfx": raw.get("rtfx"),
+        },
+    }
+
+
+def run_parakeet_coreml(
+    input_wav: Path,
+    model: str,
+    output_dir: Path,
+    language: str | None = None,
+    other_args: list[str] | None = None,
+) -> None:
+    """Transcribe with FluidAudio/CoreML Parakeet and write standard artifacts."""
+    del language, other_args
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        raise RuntimeError("FluidAudio/CoreML Parakeet requires an Apple Silicon Mac")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    binary = resolve_fluidaudio_binary()
+    with tempfile.TemporaryDirectory(prefix="transcribe-anything-coreml-") as tmp:
+        raw_path = Path(tmp) / "fluidaudio.json"
+        command = [
+            str(binary),
+            "transcribe",
+            str(input_wav.resolve()),
+            "--model-version",
+            model_version(model),
+            "--encoder-precision",
+            "int8",
+            "--metadata",
+            "--word-timestamps",
+            "--output-json",
+            str(raw_path),
+        ]
+        completed = subprocess.run(command, text=True, capture_output=True, check=False)
+        if completed.returncode:
+            raise RuntimeError(
+                f"FluidAudioCLI failed with code {completed.returncode}\n"
+                f"STDOUT: {completed.stdout}\nSTDERR: {completed.stderr}"
+            )
+        raw = json.loads(raw_path.read_text(encoding="utf-8"))
+    converted = convert_fluidaudio_result(raw)
+    _generate_output_files(converted, output_dir)

--- a/tests/test_parakeet_coreml.py
+++ b/tests/test_parakeet_coreml.py
@@ -1,0 +1,66 @@
+"""Tests for the FluidAudio/CoreML Parakeet adapter."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from transcribe_anything.parakeet_coreml import convert_fluidaudio_result, model_version
+
+
+class ParakeetCoreMLTest(unittest.TestCase):
+    def test_model_selection_defaults_to_v3(self) -> None:
+        self.assertEqual(model_version(""), "v3")
+        self.assertEqual(model_version("small"), "v3")
+        self.assertEqual(model_version("parakeet-v3"), "v3")
+        self.assertEqual(model_version("parakeet-v2"), "v2")
+        self.assertEqual(model_version("parakeet-110m"), "110m")
+
+    def test_conversion_emits_calibrated_unreviewed_filler_events(self) -> None:
+        raw = {
+            "durationSeconds": 5.0,
+            "modelVersion": "v3",
+            "processingTimeSeconds": 0.1,
+            "rtfx": 50.0,
+            "text": "Okay. Um this works.",
+            "wordTimings": [
+                {"word": "Okay.", "startTime": 0.2, "endTime": 0.7, "confidence": 0.9},
+                {"word": "Um", "startTime": 1.0, "endTime": 1.2, "confidence": 0.8},
+                {"word": "this", "startTime": 1.5, "endTime": 1.8, "confidence": 0.95},
+                {"word": "works.", "startTime": 1.9, "endTime": 2.4, "confidence": 0.97},
+            ],
+        }
+        converted = convert_fluidaudio_result(raw)
+        self.assertEqual(converted["backend"]["model"], "parakeet-v3-int8")
+        self.assertIsNone(converted["backend"]["model_revision"])
+        self.assertEqual(converted["backend"]["audited_model_revision"], "aed02740059203c4a87495924f685de3722ae9ce")
+        self.assertFalse(converted["backend"]["model_revision_enforced"])
+        self.assertEqual(len(converted["sentences"]), 2)
+        self.assertEqual(converted["filler_events"], [
+            {
+                "surface": "um",
+                "raw_surface": "Um",
+                "start": 1.0,
+                "end": 1.36,
+                "raw_end": 1.2,
+                "end_correction_s": 0.16,
+                "confidence": 0.8,
+                "event_type": "literal_filler",
+                "editorial_decision": "unreviewed",
+            }
+        ])
+
+    @patch("transcribe_anything.parakeet_coreml.platform.machine", return_value="x86_64")
+    @patch("transcribe_anything.parakeet_coreml.platform.system", return_value="Darwin")
+    def test_rejects_intel_mac(self, _system: object, _machine: object) -> None:
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        from transcribe_anything.parakeet_coreml import run_parakeet_coreml
+
+        with TemporaryDirectory() as tmp, self.assertRaisesRegex(RuntimeError, "Apple Silicon"):
+            run_parakeet_coreml(Path("audio.wav"), "", Path(tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Keep Parakeet as the default only on Apple Silicon Macs.
- Route `--device parakeet` to the audited FluidAudio/CoreML Parakeet v3 int8 backend.
- Preserve the previous MLX implementation as the explicit `--device parakeet-mlx` rollback.
- Add Parakeet v2, v3, and 110m model selectors.
- Emit word-timed standard outputs plus reviewable `um`, `uh`, `ah`, and `mmm` filler events.
- Keep acoustic detection separate from editorial removal with `editorial_decision: unreviewed`.
- Document the pinned FluidAudio source build, validated binary checksum, and honest model-revision provenance.
- Bump the fork to version 3.3.0.

## Why

The old `parakeet` help text described CoreML, but the implementation actually dispatched to `parakeet-mlx`. With the ordinary English CLI arguments, that fallback selected Parakeet v2. The frozen local evaluation found FluidAudio/CoreML v3 materially better at literal filler detection while remaining at least as fast for the intended Apple Silicon workflow.

## Impact

Apple Silicon users get the CoreML v3 int8 path by default. Intel Macs retain the existing non-Parakeet default. Users who need the former behavior can select `--device parakeet-mlx` explicitly. The FluidAudio executable is built separately and is not committed to this repository.

## Validation

- Ruff checks passed on changed Python files.
- 10 targeted tests passed; 2 platform-dependent tests skipped.
- Installed CLI end-to-end smoke test produced `out.json`, `out.txt`, `out.srt`, and `out.vtt` and detected the expected `uh` event.
- Combined filler workflow remained review-only and produced no automatic render.
